### PR TITLE
update the coc links.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,6 @@ Sponsors (otherwise known as vendors, booth staff) and other staff are subject t
 -----
 
 #### About our Community CoC
-Current Techlahoma Event Code of Conduct based on our friends in [OKCrb](http://www.okcruby.org/about/), [Burlington Ruby](http://burlingtonruby.com/conduct.html), and [JS Conf/Ada Iniative.](http://2012.jsconf.us/#/about)
+Current Techlahoma Event Code of Conduct based on our friends in [OKCrb](http://www.okcruby.org/about/), [Burlington Ruby](http://burlingtonrubyconference.com/conduct.html), and [JS Conf/Ada Iniative.](http://jsconf.com/codeofconduct.html)
 
 This work is licensed under a Creative Commons Attribution 3.0 Unported License


### PR DESCRIPTION
The Burlington Ruby Conference link has changed. And the JS Conf link is to the main site, not the 2012 site.